### PR TITLE
Change NAs to zeroes in coral values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: oceandatr
 Type: Package
 Title: Ocean Data Access
-Version: 0.2.1.3
+Version: 0.2.1.4
 Authors@R: person(given = "Jason", family = "Flower", email = "jflower@ucsb.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6731-8182"))
 Description: For retrieving and gridding ocean related data.
 License: GPL (>= 3) + file LICENSE

--- a/R/get_enviro_zones.R
+++ b/R/get_enviro_zones.R
@@ -257,8 +257,11 @@ get_enviro_data <- function(spatial_grid = NULL){
     biooracle_data[[i]] <- biooracler::download_layers(dataset_id = biooracle_datasets_info$dataset_id[i], variables = biooracle_datasets_info$variables[i], constraints = constraints)
   }
   
-  terra::rast(biooracle_data) %>%
+  biooracle_data <- terra::rast(biooracle_data) %>%
     stats::setNames(c("Chlorophyll", "Dissolved_oxygen", "Nitrate", "Minimum_temp", "Mean_temp", "Max_temp", "pH", "Phosphate", "Salinity", "Silicate", "Phytoplankton"))
+  
+  terra::crs(biooracle_data) <- "epsg:4326"
+  return(biooracle_data)
 }
 
 enviro_zones_boxplot <- function(enviro_zone, enviro_data){


### PR DESCRIPTION
Ocean areas that didn't have coral value were resulting in NAs in gridded data. These have been changed to return zeroes. Also fixed a new issue with downloaded the Bio-Oracle data not having a crs.